### PR TITLE
Retry capture

### DIFF
--- a/capture/index.js
+++ b/capture/index.js
@@ -1,42 +1,14 @@
 const getConfig = require('../core/getConfig')
 const openBrowser = require('./openBrowser')
-const resizeAndPrint = require('./resizeAndPrint')
-const removeElements = require('./removeElements')
-const waitFor = require('./waitFor')
-const disableBlinkingCursor = require('./disableBlinkingCursor')
+const retry = require('../core/retry')
+const tryCapture = require('./tryCapture')
 
 const capture = async (url, testName, options = {}) => {
   const config = getConfig()
   const browser = await openBrowser()
   const viewports = config.viewports
 
-  try {
-    const page = await browser.newPage()
-    if (options.cookies && options.cookies.length) {
-      await page.setCookie(...options.cookies)
-    }
-
-    const fullUrl = `${config.baseURL}${url}`
-
-    await page.goto(fullUrl)
-
-    if (options.delay) {
-      await waitFor(page, [options.delay])
-    }
-
-    await removeElements(page, options.removeSelectors)
-    await disableBlinkingCursor(page)
-
-    if (options.onReady) {
-      await options.onReady(page)
-    }
-
-    await resizeAndPrint(page, viewports, testName)
-    await browser.close()
-  } catch (e) {
-    await browser.close()
-    throw e
-  }
+  await retry(() => tryCapture(browser, url, testName, viewports, options, config), 3, 500)
 }
 
 module.exports = capture

--- a/capture/tryCapture.js
+++ b/capture/tryCapture.js
@@ -1,0 +1,36 @@
+const resizeAndPrint = require('./resizeAndPrint')
+const removeElements = require('./removeElements')
+const waitFor = require('./waitFor')
+const disableBlinkingCursor = require('./disableBlinkingCursor')
+
+const tryCapture = async (browser, url, testName, viewports, options, config) => {
+  try {
+    const page = await browser.newPage()
+    if (options.cookies && options.cookies.length) {
+      await page.setCookie(...options.cookies)
+    }
+
+    const fullUrl = `${config.baseURL}${url}`
+
+    await page.goto(fullUrl)
+
+    if (options.delay) {
+      await waitFor(page, [options.delay])
+    }
+
+    await removeElements(page, options.removeSelectors)
+    await disableBlinkingCursor(page)
+
+    if (options.onReady) {
+      await options.onReady(page)
+    }
+
+    await resizeAndPrint(page, viewports, testName)
+    await browser.close()
+  } catch (e) {
+    await browser.close()
+    throw e
+  }
+}
+
+module.exports = tryCapture

--- a/core/retry.js
+++ b/core/retry.js
@@ -16,7 +16,7 @@ const retry = (func, attempts, delay) => {
         attemptCount = attemptCount + 1
         await sleep(delay)
       }
-    } while (attemptCount < attempts && !result)
+    } while (attemptCount <= attempts && !result)
 
     result ? resolve(true) : reject(error)
   })

--- a/core/retry.js
+++ b/core/retry.js
@@ -1,0 +1,25 @@
+function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+const retry = (func, attempts, delay) => {
+  return new Promise(async (resolve, reject) => {
+    let attemptCount = 1;
+    let result = false;
+    let error = null;
+    do {
+      try {
+        await func()
+        result = true
+      } catch (e) {
+        error = e
+        attemptCount = attemptCount + 1
+        await sleep(delay)
+      }
+    } while (attemptCount < attempts && !result)
+
+    result ? resolve(true) : reject(error)
+  })
+}
+
+module.exports = retry

--- a/core/tests/retry.spec.js
+++ b/core/tests/retry.spec.js
@@ -46,4 +46,17 @@ describe('Retry', () => {
       assert.isAtLeast(end - start, 500)
     })
   })
+
+  const attempts = 5
+  it(`Should try ${attempts} times`, async () => {
+    let attemptCount = 0
+
+    const func = () => new Promise((resolve, reject) =>  {
+      attemptCount++
+      reject(ERROR)
+    })
+
+    return retry(func, 5, DELAY)
+      .catch(e => assert.equal(attemptCount, attempts))
+  })
 })

--- a/core/tests/retry.spec.js
+++ b/core/tests/retry.spec.js
@@ -1,0 +1,49 @@
+const { assert } = require('chai')
+const retry = require('../retry')
+
+const ERROR = new Error()
+const ATTEMPTS = 3
+const DELAY = 100
+
+describe('Retry', () => {
+  it('Should resolve if func doesnt throw an exception', async () => {
+    const func = () => new Promise((resolve => resolve()))
+
+    const result = await retry(func, ATTEMPTS, DELAY)
+
+    assert.isTrue(result)
+  })
+
+  it('Should reject if func throw an exception', async () => {
+    const func = () => new Promise((resolve, reject) => reject(ERROR))
+
+    return retry(func, ATTEMPTS, DELAY).catch(e => assert.equal(e, ERROR))
+  })
+
+  it('Should resolve if func resolves after one failed attempt', async () => {
+    let a = false;
+    const func = () => new Promise((resolve, reject) => {
+      if (a) {
+        resolve()
+      } else {
+        a = true
+        reject()
+      }
+    })
+
+    const result = await retry(func, ATTEMPTS, DELAY)
+
+    assert.isTrue(result)
+  })
+
+  it('Should wait 500ms between attempts', () => {
+    const start = new Date()
+
+    const func = () => new Promise((resolve, reject) => reject(ERROR))
+
+    return retry(func, 2, 500).catch(e => {
+      var end = new Date()
+      assert.isAtLeast(end - start, 500)
+    })
+  })
+})


### PR DESCRIPTION
As a workaround to https://github.com/mercos/robot-eyes/issues/11, seems like retry capture the image is a good practice.

This can be useful to avoid connections instability aswell.