### PR TITLE
Fix browser hanging on error

### DIFF
--- a/capture/index.js
+++ b/capture/index.js
@@ -1,14 +1,12 @@
 const getConfig = require('../core/getConfig')
-const openBrowser = require('./openBrowser')
 const retry = require('../core/retry')
 const tryCapture = require('./tryCapture')
 
 const capture = async (url, testName, options = {}) => {
   const config = getConfig()
-  const browser = await openBrowser()
   const viewports = config.viewports
 
-  await retry(() => tryCapture(browser, url, testName, viewports, options, config), 3, 500)
+  await retry(() => tryCapture(url, testName, viewports, options, config), 3, 500)
 }
 
 module.exports = capture

--- a/capture/tryCapture.js
+++ b/capture/tryCapture.js
@@ -2,8 +2,11 @@ const resizeAndPrint = require('./resizeAndPrint')
 const removeElements = require('./removeElements')
 const waitFor = require('./waitFor')
 const disableBlinkingCursor = require('./disableBlinkingCursor')
+const openBrowser = require('./openBrowser')
 
-const tryCapture = async (browser, url, testName, viewports, options, config) => {
+const tryCapture = async (url, testName, viewports, options, config) => {
+  const browser = await openBrowser()
+
   try {
     const page = await browser.newPage()
     if (options.cookies && options.cookies.length) {

--- a/index.js
+++ b/index.js
@@ -21,9 +21,6 @@ program
       .catch((e) => {
         process.exitCode = 1
 
-        if (e) {
-          throw e
-        }
         if (b.report) {
           report()
         }


### PR DESCRIPTION
I found this problem because I was bothered by this message, which appeared when the url was not available:

```
(node:21243) UnhandledPromiseRejectionWarning: Error: 2 tests failed
    at /Users/brendonbarreto/Developer/robot-eyes/commands/test/index.js:17:27
    at done (/Users/brendonbarreto/Developer/robot-eyes/node_modules/mocha/lib/mocha.js:998:7)
    at Runner.<anonymous> (/Users/brendonbarreto/Developer/robot-eyes/node_modules/mocha/lib/runner.js:1029:5)
    at Runner.emit (events.js:187:15)
    at /Users/brendonbarreto/Developer/robot-eyes/node_modules/mocha/lib/runner.js:1012:12
    at /Users/brendonbarreto/Developer/robot-eyes/node_modules/mocha/lib/runner.js:857:7
    at next (/Users/brendonbarreto/Developer/robot-eyes/node_modules/mocha/lib/runner.js:453:14)
    at Immediate.<anonymous> (/Users/brendonbarreto/Developer/robot-eyes/node_modules/mocha/lib/runner.js:520:5)
    at runCallback (timers.js:705:18)
    at tryOnImmediate (timers.js:676:5)
(node:21243) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)
(node:21243) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```

Not clear at all!